### PR TITLE
fix actionRollback return url

### DIFF
--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -4,6 +4,7 @@ namespace app\controllers;
 
 use yii;
 use yii\data\Pagination;
+use yii\helpers\Url;
 use app\components\Controller;
 use app\models\Task;
 use app\models\Project;
@@ -167,8 +168,8 @@ class TaskController extends Controller {
         $rollbackTask->title = $this->task->title . ' - ' . yii::t('task', 'rollback');
         if ($rollbackTask->save()) {
             $url = $conf->audit == Project::AUDIT_YES
-                ? '/task/'
-                : '/walle/deploy?taskId=' . $rollbackTask->id;
+                ? Url::to('@web/task/')
+                : Url::to('@web/walle/deploy?taskId=' . $rollbackTask->id);
             $this->renderJson([
                 'url' => $url,
             ]);


### PR DESCRIPTION
when walle deployed under a sub-path like http://localhost/walle, the TaskController.actionRollback return a wrong new deplay url http://localhost/walle/deploy?taskId=10 which actually shoud be http://localhost/walle/walle/deploy?taskId=10